### PR TITLE
Update tech stack link to Tech Radar URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 My name is Jack Plowman, a software engineer specialising in backend development and DevOps. My core tech stack is Python, Terraform, and AWS.
 
-Consider taking a look at my [tech stack](MY_TECH.md) if you're interested in learning more about my skills and technologies.
+Consider taking a look at my [tech stack](https://jackplowman.github.io/tech-radar/) if you're interested in learning more about my skills and technologies.
 
 ## My Stats
 


### PR DESCRIPTION
### TL;DR

Updated the tech stack link in README.md to point to a GitHub Pages site.

### What changed?

The link to the tech stack information in the README.md file has been updated. Instead of pointing to a local file (MY_TECH.md), it now directs to a GitHub Pages site (https://jackplowman.github.io/tech-radar/).

### Why make this change?

This change improves accessibility to the tech stack information by hosting it on a dedicated GitHub Pages site. It provides a more professional and easily maintainable way to showcase skills and technologies, potentially offering a better user experience for visitors interested in learning more about the author's technical expertise.