### PR TITLE
Add GitHub Metrics Workflow

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -1,0 +1,52 @@
+# Visit https://github.com/lowlighter/metrics#-documentation for full reference
+
+name: Metrics
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+  push:
+    branches: "main"
+
+permissions:
+  contents: write
+
+jobs:
+  github-metrics:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: lowlighter/metrics@v3.34
+        with:
+          token: ${{ secrets.METRICS_TOKEN }}
+
+          # Options
+          user: JackPlowman
+          template: classic
+          base: header, activity, community, repositories, metadata
+          config_timezone: Europe/London
+          plugin_habits: yes
+          plugin_habits_charts_type: classic
+          plugin_habits_days: 14
+          plugin_habits_facts: yes
+          plugin_habits_from: 200
+          plugin_habits_languages_limit: 8
+          plugin_habits_languages_threshold: 0%
+          plugin_isocalendar: yes
+          plugin_isocalendar_duration: full-year
+          plugin_languages: yes
+          plugin_languages_analysis_timeout: 15
+          plugin_languages_analysis_timeout_repositories: 7.5
+          plugin_languages_categories: markup, programming
+          plugin_languages_colors: github
+          plugin_languages_limit: 8
+          plugin_languages_recent_categories: markup, programming
+          plugin_languages_recent_days: 14
+          plugin_languages_recent_load: 300
+          plugin_languages_sections: most-used
+          plugin_languages_threshold: 0%
+          plugin_lines: yes
+          plugin_lines_history_limit: 1
+          plugin_lines_repositories_limit: 4
+          plugin_lines_sections: base

--- a/README.md
+++ b/README.md
@@ -4,9 +4,4 @@ My name is Jack Plowman, a software engineer specialising in backend development
 
 Consider taking a look at my [tech stack](https://jackplowman.github.io/tech-radar/) if you're interested in learning more about my skills and technologies.
 
-## My Stats
-
-### GitHub Stats
-
-![My Repository's Stats](https://github-readme-stats.vercel.app/api?username=JackPlowman&show_icons=true&theme=transparent)
-![My Repository's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=JackPlowman&layout=compact&theme=transparent)
+![Metrics](https://metrics.lecoq.io/JackPlowman?template=classic&isocalendar=1&lines=1&habits=1&languages=1&base=header%2C%20activity%2C%20community%2C%20repositories%2C%20metadata&base.indepth=false&base.hireable=false&base.skip=false&isocalendar=false&isocalendar.duration=full-year&languages=false&languages.limit=8&languages.threshold=0%25&languages.other=false&languages.colors=github&languages.sections=most-used&languages.indepth=false&languages.analysis.timeout=15&languages.analysis.timeout.repositories=7.5&languages.categories=markup%2C%20programming&languages.recent.categories=markup%2C%20programming&languages.recent.load=300&languages.recent.days=14&lines=false&lines.sections=base&lines.repositories.limit=4&lines.history.limit=1&lines.delay=0&habits=false&habits.from=200&habits.days=14&habits.facts=true&habits.charts=false&habits.charts.type=classic&habits.trim=false&habits.languages.limit=8&habits.languages.threshold=0%25&config.timezone=Europe%2FLondon)


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow to generate SVG metrics and updated README with dynamic metrics display.

### What changed?

- Created a new GitHub Actions workflow file `.github/workflows/generate-svg.yml`
- The workflow uses the `lowlighter/metrics` action to generate SVG metrics
- Updated `README.md` to display the generated metrics image
- Removed static GitHub stats from the README
