### PR TITLE
Update Metrics Commit Message

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -50,3 +50,4 @@ jobs:
           plugin_lines_history_limit: 1
           plugin_lines_repositories_limit: 4
           plugin_lines_sections: base
+          committer_message: "Update GitHub metrics"


### PR DESCRIPTION
## What changed?

Added the `committer_message` parameter to the GitHub metrics generation workflow. The new message is set to "Update GitHub metrics".
