### PR TITLE
Change Metrics to Commit Instead of Pull Request

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -56,5 +56,4 @@ jobs:
           token: ${{ secrets.METRICS_TOKEN }}
           committer_token: ${{ secrets.GITHUB_TOKEN }}
           committer_message: "Update GitHub metrics"
-          output_action: pull-request-squash
           output_condition: data-changed


### PR DESCRIPTION
### What changed?

The `output_action: pull-request-squash` line has been removed from the `generate-svg.yml` workflow file. This action was previously set to create a squashed pull request for the generated SVG.

