### PR TITLE
Update GitHub Metrics Cron Schedule

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -1,9 +1,10 @@
 # Visit https://github.com/lowlighter/metrics#-documentation for full reference
 
 name: Metrics
+
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 8,12,16 * * *"
   workflow_dispatch:
   push:
     branches: "main"
@@ -15,7 +16,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: lowlighter/metrics@v3.34
+      - name: Generate GitHub Metrics
+        uses: lowlighter/metrics@v3.34
         with:
           # Configuration of Metrics
           user: JackPlowman


### PR DESCRIPTION
### What changed?

Modified the cron schedule in the `generate-svg.yml` workflow file. The schedule has been changed from running every hour to running three times a day at 8:00, 12:00, and 16:00 UTC.
