### PR TITLE
Fix Code Quality Check

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -9,12 +9,13 @@ on:
   push:
     branches: "main"
 
+permissions:
+  contents: write
+
 jobs:
   github-metrics:
     name: GitHub Metrics
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Generate GitHub Metrics
         uses: lowlighter/metrics@v3.34


### PR DESCRIPTION
### What changed?

The `permissions` block has been relocated from the job level to the workflow level. The `contents: write` permission is now set globally for the entire workflow instead of being specific to the `github-metrics` job.
