### PR TITLE
Enable Habits Charts in GitHub Metrics

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -26,6 +26,7 @@ jobs:
           base: header, activity, community, repositories, metadata
           config_timezone: Europe/London
           plugin_habits: yes
+          plugin_habits_charts: yes
           plugin_habits_charts_type: classic
           plugin_habits_days: 30
           plugin_habits_facts: yes


### PR DESCRIPTION
### What changed?

The `generate-svg.yml` workflow file was updated to include the `plugin_habits_charts: yes` configuration. This enables the generation of charts for the habits plugin.