### PR TITLE
Configure Columns Display in GitHub Metrics

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Generate GitHub Metrics
         uses: lowlighter/metrics@v3.34
         with:
+          # Size
+          config_display: columns
           # Configuration of Metrics
           user: JackPlowman
           template: classic


### PR DESCRIPTION
### What changed?

Added the `config_display: columns` parameter to the GitHub Metrics action in the generate-svg.yml workflow file.
