### PR TITLE
Change GitHub Metrics Display to Large

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -21,7 +21,7 @@ jobs:
         uses: lowlighter/metrics@v3.34
         with:
           # Size
-          config_display: columns
+          config_display: large
           # Configuration of Metrics
           user: JackPlowman
           template: classic


### PR DESCRIPTION
### What changed?

Modified the `config_display` parameter in the GitHub Actions workflow file from `columns` to `large`.
