### PR TITLE
Update GitHub Metrics Cron Schedule

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -4,7 +4,7 @@ name: Metrics
 
 on:
   schedule:
-    - cron: "0 8,12,16 * * *"
+    - cron: "0 */4 * * *"
   workflow_dispatch:
   push:
     branches: "main"


### PR DESCRIPTION
### What changed?

Modified the cron schedule in the `generate-svg.yml` workflow file. The schedule was changed from running at specific hours (8, 12, and 16) to running every 4 hours.