### PR TITLE
Enable Languages Plugin in GitHub Metrics

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -37,6 +37,17 @@ jobs:
           plugin_habits_languages_threshold: 0%
           plugin_isocalendar: yes
           plugin_isocalendar_duration: full-year
+          plugin_languages: yes
+          plugin_languages_analysis_timeout: 15
+          plugin_languages_analysis_timeout_repositories: 7.5
+          plugin_languages_categories: markup, programming
+          plugin_languages_colors: github
+          plugin_languages_limit: 8
+          plugin_languages_recent_categories: markup, programming
+          plugin_languages_recent_days: 14
+          plugin_languages_recent_load: 300
+          plugin_languages_sections: most-used
+          plugin_languages_threshold: 0%
           plugin_lines: yes
           plugin_lines_history_limit: 1
           plugin_lines_repositories_limit: 4


### PR DESCRIPTION
### What changed?

The `generate-svg.yml` workflow file has been updated to include configuration for the languages plugin. This addition enables the display of language statistics in the generated SVG.

Key configurations added:
- Enabled the languages plugin
- Set analysis timeout limits
- Defined language categories and colors
- Set limits on the number of languages displayed
- Configured recent language activity tracking
- Added sections for most-used languages
- Set the threshold for language inclusion
