### PR TITLE
Remove Fork Repositories from GitHub Metrics

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -28,7 +28,6 @@ jobs:
           base: header, activity, community, repositories, metadata
           base_indepth: yes
           repositories_batch: 1000
-          repositories_forks: yes
           config_timezone: Europe/London
           plugin_habits: yes
           plugin_habits_charts: yes


### PR DESCRIPTION
### What changed?

The `repositories_forks` parameter was removed from the `generate-svg.yml` workflow file. This parameter was previously set to `yes`.
