### PR TITLE
Update Token Configuration in GitHub Metrics Workflow

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -47,7 +47,7 @@ jobs:
           plugin_lines_repositories_limit: 4
           plugin_lines_sections: base
           # Git Configuration
-          token: ${{ secrets.METRICS_TOKEN }}
+          token: NOT_NEEDED
           committer_token: ${{ secrets.GITHUB_TOKEN }}
           committer_message: "Update GitHub metrics"
           output_condition: data-changed


### PR DESCRIPTION
### TL;DR

Updated token configuration in GitHub Actions workflow

### What changed?

The `token` parameter in the `.github/workflows/generate-svg.yml` file has been changed from `${{ secrets.METRICS_TOKEN }}` to `NOT_NEEDED`.
