### PR TITLE
Pin GitHub Dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.3.5


### PR DESCRIPTION
### What changed?

- Updated `actions/checkout` from v4 to v4.2.1
- Updated `actions/dependency-review-action` from v4 to v4.3.5