### PR TITLE
Pin GitHub Dependencies

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
       - name: Lint Code Base
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
       - name: Check Markdown links


### PR DESCRIPTION
### What changed?

- Updated `actions/checkout` from v4 to v4.2.1 in two jobs:
  1. The "Lint Code Base" job
  2. The "Check Markdown links" job
