### PR TITLE
Add British English note to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,6 @@
 
 ## Description
 
+<!-- Please use British English for spelling and terminology where possible. However, if you're more comfortable using another variant don't worry about it! -->
+
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


### PR DESCRIPTION
# Pull Request

## Description

Added a comment to the pull request template encouraging the use of British English for spelling and terminology where possible. The comment also reassures contributors that using other variants is acceptable if they are more comfortable with them.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.