### PR TITLE
Update Markdown File Detection in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+*.md linguist-documentation=false
 *.md linguist-detectable


### PR DESCRIPTION
# Pull Request

## Description

This change modifies the `.gitattributes` file to ensure that Markdown files are properly detected and classified by GitHub's Linguist tool. Specifically:

- Added a new line `*.md linguist-documentation=false` to prevent Markdown files from being automatically categorised as documentation.
- Retained the existing line `*.md linguist-detectable` to ensure Markdown files are still detected by Linguist.

These changes will allow Markdown files to be included in language statistics and potentially improve the repository's visibility for contributors interested in Markdown-heavy projects.