### PR TITLE
Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       timezone: "Europe/London"
     target-branch: "main"
     groups:
-      github-action-dependencies:
+      github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to update the configuration for GitHub Actions dependencies. The most important change is renaming the group and specifying the types of updates to be applied.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R18): Renamed the `github-action-dependencies` group to `github-actions` and added `update-types` to specify "patch" and "minor" updates.