### PR TITLE
Improve GitHub Workflows

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.0
         env:
@@ -35,6 +36,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:
@@ -52,6 +54,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
-
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.5.0

--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -10,7 +10,7 @@ on:
     branches: "main"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   github-metrics:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflows to improve security and permissions. The most important changes involve setting the `persist-credentials` option to `false` and modifying repository permissions.

Security improvements:

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R21): Added `persist-credentials: false` to the `checkout` action in multiple jobs to enhance security. [[1]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R21) [[2]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R39) [[3]](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R57)
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L17-R19): Added `persist-credentials: false` and `fetch-depth: 0` to the `checkout` action to improve security and ensure a complete repository history is fetched.

Permissions adjustments:

* [`.github/workflows/generate-svg.yml`](diffhunk://#diff-158690ab8298e24898f32018d36e7725006eb11cd1c455790cfaad090285a112L13-R13): Changed repository permissions from `contents: write` to `contents: read` to follow the principle of least privilege.
