### PR TITLE
Fix GitHub Permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -64,6 +64,8 @@ jobs:
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor change to the GitHub Actions workflow file `.github/workflows/code-quality.yml`. The change adds permissions for `security-events` to the `run-zizmor` job.

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R67-R68): Added `security-events: write` permissions to the `run-zizmor` job.
