### PR TITLE
Fix Zizmor Warning

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -59,7 +59,7 @@ jobs:
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]
 
   run-zizmor:
     name: Check GitHub Actions with zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor change to the `.github/workflows/code-quality.yml` file. The change adds a comment to ignore a specific template injection warning.

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L62-R62): Added a comment to ignore the `template-injection` warning in the `Check workflow files` step.
