### PR TITLE
Fix YAML Warnings

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,6 +4,7 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
+  comments: disable
 
 ignore:
   - .linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/super-linter-configs/.yaml-lint.yml` file. The change disables the `comments` rule in the `rules:` section.

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbR7): Disabled the `comments` rule in the `rules:` section.