### PR TITLE
Fix Metrics Job

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -9,13 +9,12 @@ on:
   push:
     branches: "main"
 
-permissions:
-  contents: read
-
 jobs:
   github-metrics:
     name: GitHub Metrics
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Generate GitHub Metrics
         uses: lowlighter/metrics@v3.34


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the GitHub Actions workflow configuration in the `.github/workflows/generate-svg.yml` file. The change modifies the permissions for the `github-metrics` job.

Permissions update:

* [`.github/workflows/generate-svg.yml`](diffhunk://#diff-158690ab8298e24898f32018d36e7725006eb11cd1c455790cfaad090285a112L12-R17): Changed the permissions for the `github-metrics` job from `contents: read` to `contents: write`.