### PR TITLE
Remove Actionlint Job

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,7 +4,8 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
-  comments: disable
+  comments:
+    min-spaces-from-content: 1
 
 ignore:
   - .linkspector.yml

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,21 +46,6 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
-  run-actionlint:
-    name: Check GitHub Actions with actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]
-
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the YAML linting configuration and the code quality workflow. The changes focus on improving the configuration rules and removing redundant steps in the workflow.

Updates to YAML linting configuration:

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbL7-R8): Modified the `comments` rule to require a minimum of one space from the content.

Simplification of code quality workflow:

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L49-L63): Removed the `run-actionlint` job, which included steps for checking out the repository, installing actionlint, and checking workflow files.
