### PR TITLE
Skip JSON Repo

### DIFF
--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -43,6 +43,7 @@ jobs:
           plugin_languages_recent_load: 1000
           plugin_languages_sections: most-used
           plugin_languages_threshold: 0%
+          plugin_languages_skipped: RepoOrchestratorState
           # Git Configuration
           token: ${{ secrets.METRICS_TOKEN }}
           committer_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/generate-svg.yml` file. The change adds a new configuration option to skip the `RepoOrchestratorState` plugin language during the generation of SVGs.

* [`.github/workflows/generate-svg.yml`](diffhunk://#diff-158690ab8298e24898f32018d36e7725006eb11cd1c455790cfaad090285a112R46): Added `plugin_languages_skipped` configuration to skip `RepoOrchestratorState` plugin language.