### PR TITLE
Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,7 +30,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configs/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the GitHub Actions workflow configuration for checking Markdown links. The most important changes are:

* Updated the `runs-on` parameter to use `ubuntu-latest` instead of a specific version (`ubuntu-22.04`).
* Updated the `UmbrellaDocs/action-linkspector` action to version `v1.2.5` from `v1.2.4`.