### PR TITLE
Fix Cache Deletion Permissions and Command

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -18,12 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: List and delete caches
-        run: |
-          caches=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/caches | jq -r '.actions_caches[].id')
-          for cache in $caches; do
-            echo "Deleting cache: $cache"
-            gh api --method DELETE -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/caches/$cache
-          done
+      - name: Delete caches
+        run: gh cache delete --all --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Delete caches
         run: gh cache delete --all --repo ${{ github.repository }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant update to the cache management process in the GitHub Actions workflow. The changes simplify the cache deletion process and update the environment variable for the GitHub token.

Changes to cache management:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL21-R24): Simplified the cache deletion process by replacing the manual API call with the `gh cache delete --all` command.
* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL21-R24): Updated the environment variable for the GitHub token from `GH_TOKEN` to `secrets.GH_TOKEN`.
