### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: origin/main
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.4
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -78,7 +78,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.2
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.2
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
       - name: Run Lefthook Validate

--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - name: Generate GitHub Metrics
-        uses: lowlighter/metrics@v3.34
+        uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6 # v3.34
         with:
           # Size
           config_display: large

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,7 +21,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: micnncim/action-label-syncer@v1.3.0
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows by pinning actions to specific commit SHAs instead of version tags. This change enhances security and reliability by ensuring that the actions used are immutable and cannot be altered unexpectedly. Below are the most significant changes grouped by workflow:

### Updates to `.github/workflows/code-checks.yml`:
* Updated `super-linter/super-linter/slim` action to commit SHA `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2`.
* Updated `UmbrellaDocs/action-linkspector` action to commit SHA `a0567ce1c7c13de4a2358587492ed43cab5d0102`.
* Updated `extractions/setup-just` action to commit SHA `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff`.
* Updated `astral-sh/setup-uv` action to commit SHA `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86` in two separate steps [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L81-R81) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L104-R104).

### Updates to `.github/workflows/generate-svg.yml`:
* Updated `lowlighter/metrics` action to commit SHA `65836723097537a54cd8eb90f61839426b4266b6`.

### Updates to `.github/workflows/pull-request-tasks.yml`:
* Updated `pascalgn/size-label-action` to commit SHA `f8edde36b3be04b4f65dcfead05dc8691b374348`.

### Updates to `.github/workflows/sync-labels.yml`:
* Updated `micnncim/action-label-syncer` to commit SHA `3abd5ab72fda571e69fffd97bd4e0033dd5f495c`.