### PR TITLE
Remove pinact-verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -125,17 +125,3 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.15
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the GitHub Actions workflow by removing an unused job and its associated steps.

Workflow cleanup:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L128-L141): Removed the `pinact-verify` job, which included steps for checking out the repository and installing the latest version of `uv`. This job was deemed unnecessary and has been eliminated to streamline the workflow.