### PR TITLE
Bump GitHub Action Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -78,15 +78,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@v3.28.16
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -101,9 +99,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 
@@ -119,9 +115,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.15
+        uses: github/codeql-action/init@v3.28.16
         with:
           languages: actions
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.15
+        uses: github/codeql-action/analyze@v3.28.16

--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
   push:
-    branches: "main"
+    branches: ["main"]
 
 permissions: {}
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.8
+min_version: 1.11.12
 colors: true
 
 output:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and configurations in the repository's workflows and tools. The changes include upgrading action versions in GitHub workflows, modifying branch configuration, and updating the minimum required version of `lefthook`.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L81-R87): Updated the `setup-uv` action to version `6.0.1` and the `codeql-action` actions (`upload-sarif`, `init`, and `analyze`) to version `v3.28.16` for improved compatibility and features. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L81-R87) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L104-R102) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L122-R123)
* [`.github/workflows/generate-svg.yml`](diffhunk://#diff-158690ab8298e24898f32018d36e7725006eb11cd1c455790cfaad090285a112L10-R10): Changed the `push` branch configuration from `"main"` to `["main"]` to align with YAML array syntax.

### Tool configuration update:

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL2-R2): Updated the minimum required version of `lefthook` from `1.11.8` to `1.11.12` to ensure compatibility with newer features or fixes.
