### PR TITLE
Swap SuperLinter to Full Version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
+
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -14,7 +14,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/*"
+          - "super-linter/super-linter"
         update-types:
           - "patch"
           - "minor"

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: origin/main


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the configuration for Dependabot and GitHub Actions workflows, specifically focusing on dependency maintenance and the usage of the `super-linter` tool.

### Dependabot configuration updates:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R2-L3): Removed a comment related to maintaining dependencies for GitHub Actions.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R17): Updated the `exclude-patterns` in the `updates` section to explicitly exclude `super-linter/super-linter` instead of the broader `super-linter/*`.

### GitHub Actions workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L27-R27): Updated the `uses` reference for `super-linter` to point directly to `super-linter/super-linter` instead of `super-linter/super-linter/slim`.