### PR TITLE
Bump SuperLinter to 7.4.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,14 +24,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: origin/main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
-          EDITORCONFIG_FILE_NAME: .editorconfig-checker.json
 
   check-markdown-links:
     name: Check Markdown links


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the linting configuration in the GitHub Actions workflow to use a newer version of the `super-linter` tool.

### Workflow configuration updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L27-L34): Updated `super-linter` from version `7.3.0` to `7.4.0` by changing the commit hash in the `uses` field. Removed the `EDITORCONFIG_FILE_NAME` environment variable, as it is no longer required.