### PR TITLE
Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,21 +42,14 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          languages: actions
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+    strategy:
+      matrix:
+        language: [actions]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis configuration in the GitHub Actions workflow to use a reusable workflow, simplifying the setup and improving maintainability.

### Workflow configuration updates:

* Renamed the job from `run-codeql-analysis` to `codeql-checks` for better clarity.
* Replaced the inline CodeQL setup and analysis steps with a reusable workflow from `JackPlowman/reusable-workflows`. This change reduces duplication and centralizes the configuration.
* Updated job permissions to explicitly set `contents: read` and `security-events: write`.
* Introduced a matrix strategy to define the language (`actions`) dynamically for the reusable workflow.