### PR TITLE
Update checkout action to v5

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,7 +22,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to use a newer version of the checkout action, ensuring improved reliability and access to the latest features and fixes.

* GitHub Actions: Updated the `actions/checkout` step in `.github/workflows/code-checks.yml` from version `v4.2.2` to `v5.0.0` to use the latest stable release.