### PR TITLE
Add GitHub Workflow permission notes

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -30,7 +30,7 @@ jobs:
     name: CodeQL Analysis
     permissions:
       contents: read
-      security-events: write
+      security-events: write #
     strategy:
       matrix:
         language: [actions]

--- a/.github/workflows/generate-svg.yml
+++ b/.github/workflows/generate-svg.yml
@@ -16,7 +16,7 @@ jobs:
     name: GitHub Metrics
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # For committing the updated SVG file
     steps:
       - name: Generate GitHub Metrics
         uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6 # v3.34

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -11,7 +11,7 @@ jobs:
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:
-      pull-requests: write
+      pull-requests: write # For writing labels and comments on PRs
     uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Configure Labels
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # For writing labels to the repository
     uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@e77e648233b977246ecdb30836e2360b33acd1d3 # v2025.09.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes minor improvements to several GitHub Actions workflow files by adding clarifying comments to permission settings. These comments explain the purpose of each permission granted, making the workflows easier to understand and maintain.

Most important changes:

**Workflow permissions documentation:**

* Added comments to `pull-requests: write` and `contents: write` permissions in `.github/workflows/pull-request-tasks.yml`, `.github/workflows/sync-labels.yml`, and `.github/workflows/generate-svg.yml` to clarify their intended use [[1]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL14-R14) [[2]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18) [[3]](diffhunk://#diff-158690ab8298e24898f32018d36e7725006eb11cd1c455790cfaad090285a112L19-R19).
* Added a comment to the `security-events: write` permission in `.github/workflows/code-checks.yml` for additional clarity.