### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@1b9a61560b067a94456fc14816b414b3f1d8e623 # v2026.04.03.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@c7d13342f6f54653bc35dc14d5a19dfa44821b18 # v2026.04.11.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@1b9a61560b067a94456fc14816b414b3f1d8e623 # v2026.04.03.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@c7d13342f6f54653bc35dc14d5a19dfa44821b18 # v2026.04.11.01
     with:
       language: ${{ matrix.language }}
 
@@ -38,6 +38,6 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@1b9a61560b067a94456fc14816b414b3f1d8e623 # v2026.04.03.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@c7d13342f6f54653bc35dc14d5a19dfa44821b18 # v2026.04.11.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,6 +15,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@1b9a61560b067a94456fc14816b414b3f1d8e623 # v2026.04.03.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@c7d13342f6f54653bc35dc14d5a19dfa44821b18 # v2026.04.11.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1b9a61560b067a94456fc14816b414b3f1d8e623 # v2026.04.03.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@c7d13342f6f54653bc35dc14d5a19dfa44821b18 # v2026.04.11.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.8.1
+          - prettier@3.8.3
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.48.1
+          - rust-just==1.50.0
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false
@@ -69,7 +69,7 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.0
+          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.2
         args: ["run", "--verify", "--check"]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and reusable workflow references to their latest versions in both GitHub Actions workflow files and pre-commit configuration. These updates help ensure the project uses the most recent features, bug fixes, and security improvements from upstream sources.

**GitHub Actions workflow updates:**

* Updated all references to reusable workflows in `.github/workflows` (`common-clean-caches.yml`, `codeql-analysis.yml`, `common-code-checks.yml`, `common-pull-request-tasks.yml`, `common-sync-labels.yml`) to use version `c7d13342f6f54653bc35dc14d5a19dfa44821b18` (`v2026.04.11.01`). This ensures consistency and brings in the latest improvements and fixes from the shared workflow repository. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L30-R30) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L41-R41) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL18-R18) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L23-R23)

**Pre-commit hook dependency updates:**

* Upgraded the `zizmor-pre-commit` hook to version `v1.24.1` for improved linting and checks.
* Bumped `prettier` from `3.8.1` to `3.8.3` and `rust-just` from `1.48.1` to `1.50.0` for formatting hooks, ensuring compatibility and latest formatting features.
* Updated `pinact` from `v3.9.0` to `v3.9.2` for GitHub Actions YAML validation, bringing in recent fixes and enhancements.