### PR TITLE
Update Prek Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,8 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v4.1.0
+          - github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0
         args: ["run", "--verify", "--check"]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false
+        language_version: "go1.26.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.8.3
+          - prettier@3.8.4
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.50.0
+          - rust-just==1.52.0
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false
@@ -69,7 +69,7 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.2
+          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v4.1.0
         args: ["run", "--verify", "--check"]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies in the `.pre-commit-config.yaml` file to keep pre-commit hooks up to date with their latest versions. These changes help ensure we get the latest features, bug fixes, and security improvements from these tools.

Dependency updates:

* Updated the `zizmor-pre-commit` hook to version `v1.25.2` for improved linting and checks.
* Updated `prettier` to version `3.8.4` for formatting markdown, YAML, and JSON files.
* Updated `rust-just` to version `1.52.0` for the Justfile format check.
* Updated `pinact` to version `v4.1.0` for verifying and checking GitHub Actions workflows.