### PR TITLE
Fix Prek Freeze

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek autoupdate --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -110,4 +110,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `Justfile` related to the `prek` update process. The main change is adding the `--freeze` flag to the `prek autoupdate` command in the `prek-update-hooks` recipe, which likely prevents automatic updates to certain dependencies. Additionally, the `prek-update-additional-dependencies` step has been removed from the `update` recipe.

* Added the `--freeze` flag to the `prek autoupdate` command in `prek-update-hooks` to prevent certain updates during the prek update process.
* Removed the `prek-update-additional-dependencies` step from the `update` recipe in the `Justfile`.