### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate --freeze
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates tooling related to the `prek` pre-commit framework. The main changes are upgrading the minimum required version of `prek` and updating the command used for updating hooks to match the latest `prek` CLI.

Tooling updates:

* Updated the `minimum_prek_version` in `.pre-commit-config.yaml` from `0.3.0` to `0.4.0` to require a newer version of `prek`.
* Changed the `prek-update-hooks` command in the `Justfile` from `prek autoupdate --freeze` to `prek update --freeze` to reflect the updated CLI command.