### PR TITLE
Update Prek Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
+    rev: 64a97fb7fa63188393d3215c6e312f5f9c6d0f78 # frozen: v1.27.0
     hooks:
       - id: zizmor
         name: Zizmor
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.56.0
+          - rust-just==1.57.0
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.pre-commit-config.yaml` file to keep pre-commit hooks and dependencies up-to-date. The main changes are version bumps for a pre-commit hook and a dependency.

Dependency and tool version updates:

* Updated the `zizmor-pre-commit` hook to version `v1.27.0` to include the latest features and fixes.
* Upgraded the `rust-just` dependency to version `1.57.0` for the `just` hook, ensuring compatibility and access to recent improvements.