### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@52b5547a80bbde1f87300170d9f129d7829f17c6 # v2026.07.11.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1 # v2026.07.24.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@52b5547a80bbde1f87300170d9f129d7829f17c6 # v2026.07.11.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1 # v2026.07.24.01
     with:
       language: ${{ matrix.language }}
 
@@ -38,6 +38,6 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@52b5547a80bbde1f87300170d9f129d7829f17c6 # v2026.07.11.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1 # v2026.07.24.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,6 +15,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@52b5547a80bbde1f87300170d9f129d7829f17c6 # v2026.07.11.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1 # v2026.07.24.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@52b5547a80bbde1f87300170d9f129d7829f17c6 # v2026.07.11.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1 # v2026.07.24.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 64a97fb7fa63188393d3215c6e312f5f9c6d0f78 # frozen: v1.27.0
+    rev: 067260dc5fe6ea86b7551bfd6f8b3ba4e6c93129 # frozen: v1.28.0
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.9.5
+          - prettier@3.9.6
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -69,7 +69,7 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0
+          - github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.1
         args:
           [
             "run",
@@ -80,4 +80,4 @@ repos:
           ]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false
-        language_version: "go1.26.4"
+        language_version: "go1.26.5"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and reusable workflows to their latest versions for both GitHub Actions workflows and pre-commit hooks. These updates ensure the project benefits from the latest features, bug fixes, and security improvements.

**GitHub Actions Workflow Updates:**

* Updated all references to reusable workflows in `.github/workflows` files (`clean-caches.yml`, `code-checks.yml`, `pull-request-tasks.yml`, `sync-labels.yml`) to use version `v2026.07.24.01` (`6f86b6bb4c690a8f0794f1654cb7b0118c59b9d1`). This affects common cache cleaning, code checks, pull request tasks, and label syncing workflows. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L30-R30) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L41-R41) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL18-R18) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L23-R23)

**Pre-commit Hook Updates:**

* Upgraded the `zizmor-pre-commit` repo hook to version `v1.28.0` (`067260dc5fe6ea86b7551bfd6f8b3ba4e6c93129`).
* Updated the `prettier` dependency to version `3.9.6` for formatting checks.
* Upgraded the `pinact` dependency to version `v4.1.1` and the Go language version to `go1.26.5` for workflow YAML checks. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L72-R72) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L83-R83)